### PR TITLE
Fix QtMultimedia include

### DIFF
--- a/mpd-interface/httpstream.cpp
+++ b/mpd-interface/httpstream.cpp
@@ -25,7 +25,9 @@
 #include "mpdconnection.h"
 #include "mpdstatus.h"
 #include "gui/settings.h"
+#ifndef LIBVLC_FOUND
 #include <QtMultimedia/QMediaPlayer>
+#endif
 #include <QTimer>
 
 static const int constPlayerCheckPeriod=250;


### PR DESCRIPTION
Don't include <QtMultimedia/QMediaPlayer> if the VLC backend is used.